### PR TITLE
Fairly extensive page celanup

### DIFF
--- a/Blocks/MovingBlock36.md
+++ b/Blocks/MovingBlock36.md
@@ -14,23 +14,25 @@ Special properties that B36 has which might be useful include:
 - Entities can see through it but cannot path through it;
 - Being destroyed only through an explosion;
 - Being unreplaceable by the player
+
 ### Hitbox
 Like most blocks, the B36 has a hitbox. A B36 hitbox is very interesting as it can be offset from where the B36 is actually located. This can be seen if you do the following:
-Go to the world border
-Place a piston facing into the world border, with water on the other side.
-Extend the piston
-Without unpowering the piston, break the piston
-Notice the invisible B36 on the other side of the border, and then walk into the invisible hitbox that is still there server-side
+1. Go to the world border
+2. Place a piston facing into the world border, with water on the other side.
+3. Extend the piston
+4. Without unpowering the piston, break the piston
+5. Notice the invisible B36 on the other side of the border, and then walk into the invisible hitbox that is still there server-side
 
 ![b36hitbox](https://cdn.discordapp.com/attachments/793179568508108820/807318838139813948/WorldBorder_B36.png)
-In this example, the hitbox stays in its original state, at the position it came from because the tile entity isn't processed outside of the world border. The same thing happens in border-loaded chunks, for the same reason.
+In this example, the hitbox stays in its original state, at the position it came from because the tile entity isn't processed outside of the world border. The same thing happens in border-loaded chunks, for the same reason.  
 When processed, the tile entity moves the hitbox and all entities colliding with it by half a block. Because piston extensions are three ticks long, this occurs three times. On the final tick, the B36 tile entities are turned back into normal blocks. That final tick can be forced to execute in the block event phase of a tick when a sticky piston tries to retract a B36, or a headless sticky piston retracts into a B36 with a movable block in front.
+
 ## Creating a B36
 Creating a B36 without it turning into other blocks can be complex. You can create a tile entity-less B36; only the block will be there, without a tile entity to turn it back into a block. Alternatively, you can prevent the tile entity from being processed by creating it outside of the world border or in a border-loaded chunk.
 
 The usual method is using an explosion to blow up the tile entity in the same tick that a piston extends by using budded pistons, causing a tile entity-less B36 to be created in its place. It is no longer possible to create a tile entity-less B36 in 1.17+, as B36 data is now stored globally.
 It can now be created with update suppression in the tick, causing a crash:
-https://www.youtube.com/watch?v=xXncCVzpg38
+[https://www.youtube.com/watch?v=xXncCVzpg38](https://www.youtube.com/watch?v=xXncCVzpg38)
 ![simplified setup](https://cdn.discordapp.com/attachments/360084811408211988/935278303059775589/2022-01-24_22.00.57.png)
 
 ## Tile Entity Data

--- a/BugsAndExploits/TntDuping.md
+++ b/BugsAndExploits/TntDuping.md
@@ -1,5 +1,3 @@
-
-
 ---
 title: Tnt duplication
 description: Explaination of tnt duplication
@@ -10,16 +8,15 @@ description: Explaination of tnt duplication
 ## History
 TNT Duplication, or TNT Duping, was first discovered in 1.9 by myren eario but was not used as it was slightly impractical before the addition of slime blocks and not well known. Methods have then been discovered for all versions except 1.0 to 1.2 and 1.8.
 It gained popularity with the invention of world eaters.
-### Opposition
-Mojang historically opposes TNT Duping as they consider it an exploit, and tried 4 times to fix it, but in 1.16 snapshots they have declared they will leave it in the game for the time being, due to a lack of replacement method
-https://www.reddit.com/r/Minecraft/comments/fkt9jf/anchor_yourself_to_the_nether_snapshot_20w12a_is/fkv33q3?utm_source=share&utm_medium=web2x&context=3
- for what TNT duping currently does.
+## Opposition
+Mojang historically opposes TNT Duping as they consider it an exploit, and tried 4 times to fix it, but in 1.16 snapshots they have declared they will leave it in the game for the time being, due to a lack of replacement method for what TNT duping currently does:
+[https://www.reddit.com/r/Minecraft/comments/fkt9jf/anchor_yourself_to_the_nether_snapshot_20w12a_is/fkv33q3](https://www.reddit.com/r/Minecraft/comments/fkt9jf/anchor_yourself_to_the_nether_snapshot_20w12a_is/fkv33q3)
 ## Mechanic
 TNT Duping works by using piston pushing behavior to make the TNT both light and move at once, creating a moving TNT block and a TNT entity. The order this follows is:
 The piston, in the same tick it powers but before moving, creates a list of the blocks in front of it that need to be moved.
 The TNT gets ignited. In order to do this, the update that powers it needs to come from
 - a moving rail (1.12 and below) being replaced
-- anything that pop off from a state update (supporting block removed)
+- anything that pop off from a state update (supporting block removed)  
 If it's a brittle block, that block must not be in front of a moved block because it will be placed in the broken block list that will be handled separately
 - a redstone component that hard power being moved or destroyed
 
@@ -27,7 +24,8 @@ A few of them can be reused because they are movable
 
 - coral fan when the base is replaced
 - carpet on top of a piston arm. The piston arm is removed just before moving block are created and leave an empty space that break the carpet, also duping it
--  lit observer being replaced
+- lit observer being replaced
+
 These specific blocks are able to create a normal update after the list of blocks to be moved is created, but before some of the moved blocks have been removed.
 That needs to happen before the TNT block is removed: before a block behind the tnt replaces it. if there is no blocks, it can be after the moving TNT was created.
 This update can also be propagated through other blocks, as long as it is instant (for example using rails, dust, noteblocks (1.13+), or TNT itself), which allows for up to 11 TNT to be duplicated using a single piston push, the 12th block being for updating.

--- a/BugsAndExploits/UpdateSuppression.md
+++ b/BugsAndExploits/UpdateSuppression.md
@@ -8,12 +8,15 @@ description: update suppression explanation and usages
 
 Update suppression is a very useful method that can be used to prevent a block from receiving an update. It does this by filling the memory stack of the server, once the stack overflows it throws an error preventing all code that would have run after to prevent getting executed. This also causes a server crash unless surrounded by a try-catch, which player interactions do! Using player interactions you are able to use update suppression without crashing the server.
 ## Side-effects/Uses:
-- Portal Slicing
-Using the update order of blocks you are able to do something called portal slicing. Which is a technic to quickly make large update suppressed portals.
-[https://www.youtube.com/watch?v=VSpqrWRefA4 Video] Discovered by: _Kayleigh
-- Soulbound chests
-Using an update suppressor you are able to suppress the chest exiting packet, allowing you to bind your player to a chest, this results in many interesting side effects. post on soulbound chests coming soon
-[https://www.youtube.com/watch?v=RchVIanvMVg Video] Discovered by: PR0CESS :https://www.youtube.com/watch?v=VSpqrWRefA4
-- item shadowing(1.17-)
-cause two item to reference the same stack, resulting in a linked status where both keep the same amount of item regardless of the distance Discovered by: PR0CESS and FallenBreath
-https://www.youtube.com/watch?v=mTeYwq7HaEA
+### Portal Slicing
+Using the update order of blocks you are able to do something called portal slicing, which is a technique to quickly make large update suppressed portals.
+Showcase video: [https://www.youtube.com/watch?v=VSpqrWRefA4](https://www.youtube.com/watch?v=VSpqrWRefA4)
+Discovered by: \_Kayleigh
+### Soulbound chests
+Using an update suppressor you are able to suppress the chest exiting packet, allowing you to bind your player to a chest, this results in many interesting side effects. Post on soulbound chests coming soon.
+Showcase video: [https://www.youtube.com/watch?v=RchVIanvMVg](https://www.youtube.com/watch?v=RchVIanvMVg)
+Discovered by: PR0CESS: [https://www.youtube.com/watch?v=VSpqrWRefA4](https://www.youtube.com/watch?v=VSpqrWRefA4)
+### Item shadowing(1.17-)
+Cause two item to reference the same stack, resulting in a linked status where both keep the same amount of item regardless of the distance.  
+Showcase video: [https://www.youtube.com/watch?v=mTeYwq7HaEA](https://www.youtube.com/watch?v=mTeYwq7HaEA)
+Discovered by: PR0CESS and FallenBreath

--- a/BugsAndExploits/UpdateSuppression.md
+++ b/BugsAndExploits/UpdateSuppression.md
@@ -7,16 +7,19 @@ description: update suppression explanation and usages
 # update suppression
 
 Update suppression is a very useful method that can be used to prevent a block from receiving an update. It does this by filling the memory stack of the server, once the stack overflows it throws an error preventing all code that would have run after to prevent getting executed. This also causes a server crash unless surrounded by a try-catch, which player interactions do! Using player interactions you are able to use update suppression without crashing the server.
+
 ## Side-effects/Uses:
 ### Portal Slicing
-Using the update order of blocks you are able to do something called portal slicing, which is a technique to quickly make large update suppressed portals.
-Showcase video: [https://www.youtube.com/watch?v=VSpqrWRefA4](https://www.youtube.com/watch?v=VSpqrWRefA4)
-Discovered by: \_Kayleigh
+Using the update order of blocks you are able to do something called portal slicing, which is a technique to quickly make large update suppressed portals.  
+Showcase video: [https://www.youtube.com/watch?v=VSpqrWRefA4](https://www.youtube.com/watch?v=VSpqrWRefA4)  
+Discovered by: \_Kayleigh  
+
 ### Soulbound chests
-Using an update suppressor you are able to suppress the chest exiting packet, allowing you to bind your player to a chest, this results in many interesting side effects. Post on soulbound chests coming soon.
-Showcase video: [https://www.youtube.com/watch?v=RchVIanvMVg](https://www.youtube.com/watch?v=RchVIanvMVg)
+Using an update suppressor you are able to suppress the chest exiting packet, allowing you to bind your player to a chest, this results in many interesting side effects. Post on soulbound chests coming soon.  
+Showcase video: [https://www.youtube.com/watch?v=RchVIanvMVg](https://www.youtube.com/watch?v=RchVIanvMVg)  
 Discovered by: PR0CESS: [https://www.youtube.com/watch?v=VSpqrWRefA4](https://www.youtube.com/watch?v=VSpqrWRefA4)
+
 ### Item shadowing(1.17-)
 Cause two item to reference the same stack, resulting in a linked status where both keep the same amount of item regardless of the distance.  
-Showcase video: [https://www.youtube.com/watch?v=mTeYwq7HaEA](https://www.youtube.com/watch?v=mTeYwq7HaEA)
+Showcase video: [https://www.youtube.com/watch?v=mTeYwq7HaEA](https://www.youtube.com/watch?v=mTeYwq7HaEA)  
 Discovered by: PR0CESS and FallenBreath

--- a/BugsAndExploits/ZeroTickFarms.md
+++ b/BugsAndExploits/ZeroTickFarms.md
@@ -6,8 +6,8 @@ description: How a zero tick farms work
 
 # Zero tick farms
 
-A zero tick farm is a farm that relies on replacing the block a crop (which grows on top of itself) is resting on, which forces it to grow a stage. This but however was patched in 20w12a and does not work in 1.16+.
+A zero tick farm is a farm that relies on replacing the block a crop (which grows on top of itself) is resting on, which forces it to grow a stage. This bug however was patched in 20w12a and does not work in 1.16+.
 
-## mechanic
-deleting a block the plant is resting on schedule a tile tick on some crops that doesn't break instantly. It will check 1 gt later if it break itself.
-But in the case where you replaced a block before this check, it will execute the rest of the tile tick that grow the plant, that is normally called on a random tick
+## Mechanic
+Deleting the block that a plant is resting on will schedule a tile tick on some crops that don't break instantly. It will then check 1 gt later if it should now break.
+However, in the case where the block has been replaced before this check, it will execute the rest of the tile tick that grows the plant, something that is normally only called when the plant block gets randomticked.

--- a/Entities/EntityTransport.md
+++ b/Entities/EntityTransport.md
@@ -5,24 +5,21 @@ description: Mechanics used for entity transport with examples
 
 # entity transport
 
-Different ways to move entities
-1. Entity velocity
-Applied every time the entity tick,you can accumulate entity velocity
-Entities have a friction coefficient even on air,x0.99 or x0.98 applied every time the entity tick
-- cramming
-add a small velocity each tick
-- slime
-set velocity in an axis to 1 block per second unless the velocity is already higher
-- explosion
-add a velocity
-2. Piston pushing
-tile entity of moving pistons pushing entity,capped at 0.51 block per axis per gt
-3. Minecart clip
-A minecart will clip to a rail if his feet position is in the rail block or the block above,it will move to a postion depending on the curve and slope of the rail,up to 0.75 block sideway with curved rail,1.9375 block downward
+## Different ways to move entities
+### Entity velocity
+Applied every time the entity tick, you can accumulate entity velocity
+Entities have a friction coefficient (even when on air) of x0.99 or x0.98, which is applied every time the entity ticks.
+- Cramming: Add a small velocity each tick
+- Slime: Set velocity in an axis to 1 block per second unless the velocity is already higher
+- Explosion: Add a velocity
+### Piston pushing  
+Tile entity of moving pistons pushing entity, capped at 0.51 block per axis per gt
+### Minecart snapping
+A minecart will snap to a rail if his feet position is in the rail block or the block above, it will move to a postion depending on the curve and slope of the rail, up to 0.75 block sideway with curved rail, 1.9375 block downward
 
-Examples:
-- 10 bps piston conveyor:piston pushing 0.5 block/gt
-- 20-30 bps piston and slime conveyor:piston pushing: 0.5 block/gt+slime: 1 block/gt velocity
-- piston bolt,40 bps minecart deelevator:piston pushing:0.5 block/gt + minecart sideway clip:0.5 block/gt
-- lazy entity laucher: cramming velocity accumulated while the entity is not ticking
-- tnt cannons: explosions in 1 or more tick if lazy acceleration
+## Examples: 
+- 10 bps piston conveyor: piston pushing 0.5 block/gt
+- 20-30 bps piston and slime conveyor: piston pushing: 0.5 block/gt+slime: 1 block/gt velocity
+- Piston bolt, 40 bps minecart deelevator: piston pushing: 0.5 block/gt + minecart sideways snapping: 0.5 block/gt
+- Lazy entity laucher: cramming velocity accumulated while the entity is not ticking
+- Tnt cannons: explosions in 1 tick (or more if "lazy acceleration" is utilized).

--- a/GameMechanics/BlockUpdates.md
+++ b/GameMechanics/BlockUpdates.md
@@ -1,5 +1,3 @@
-
-
 ---
 title: Block updates and update detectors
 description: Description and usage of block updates and update detectors
@@ -7,12 +5,12 @@ description: Description and usage of block updates and update detectors
 
 # block updates and update detectors
 
-Minecraft has a game mechanic called Updates. Redstone Components, liquids, sand, and many other things rely on these to determine if something needs to be done.
-When you flick a lever adjacent to a trapdoor, the trapdoor will change state. It receives Block Updates, which make it see if it's not in the state it should be in, and then it changes state to the state it thinks it should be. 
+Minecraft has a game mechanic called Updates. Redstone Components, liquids, sand, and many other things rely on these to determine if something needs to be done.  
+When you flick a lever adjacent to a trapdoor, the trapdoor needs to change state. It receives a Block Update from the lever, which make it see if it's not in the state it should be in, and then it changes state to the state it thinks it should be. 
 
-However, in certain cases, something affected by updates will be in a condition where it should do something, but needs an update to realize that it needs to do something, despite the update not being what made it need to do something.  While some of these may seem like bugs, with some having been reported on the bug tracker, many are just part of maintaining game performance or original behavior, generally in redstone where it's frequently used.
+However, in certain cases, something affected by updates will be in a condition where it should do something, but it has not received the update it needs to realize this. While some of these may seem like bugs, with some having been reported on the bug tracker, many are just part of maintaining game performance or original behavior, generally in redstone where it's frequently used.
 
-In the code block updates are a call that execute a function specific to the block. This call itself can send other block updates if the block changed and need to update neighboring blocks. This create a recursive call and stop until there no block to update. Each call in another call add memory in the program stack. If the calls go too far in depth, it will consume all the memory in the stack and create a stack overflow error, causing update suppression.
+In the code block updates are a call that execute a function specific to the block. This call itself can send other block updates if the block changed and need to update neighboring blocks. This will create a recursive call that will continue until there are no more blocks to update. Each call within another call adds memory in the program stack. If the calls go too far in depth, it will consume all the memory in the stack and create a stack overflow error, causing update suppression.
 
 To make a block update detector you may simply place a sticky piston facing up, with a single slime block on top of the piston and a redstone block on top of the slime block. Then when a block update occurs on the piston it will extend and then retract unless further updated.
 
@@ -56,30 +54,29 @@ Comparator updates can be detected only with a comparator, and only if the compa
 ## Block update detection
 A block which is in a state where it will react to block updates is called "Budded". BUDs are redstone contraptions which react to block updates and reset after receiving block updates. There are circumstances which will lead to a block being budded which are not practical to be reset and are not addressed here.
 1. For solely block updates:
-Examples:
-- For some redstone components: 
-- - Pistons can be budded by being unable to extend upon being powered, or when retracting into a powered position where they cannot extend.
-Droppers, Dispensers, and pistons can be budded by Quasi Connectivity.
-Powered rails and activator rails can become budded due to their circumstances of deciding when they are no longer powered.
-In the case of a piston pushing what was powering it, before the piston finishing extending.
-- - Rails may be budded for which direction or slope they need to be, specifically with moving rails around.
-- For all redstone component that react to received power:
-- - By moving or removing a detector rail into/out of a location where it would power something through the block it's on, as that does not send non adjacent updates so long as it doesn't change powered state.
-- - By powered redstone dust changing its direction, making redstone components budded by the direction change sending no block updates.
-- - By a target block reaching a destination after having a tile tick sending no updates on reaching the destination going into a location where it would be powered by redstone dust, ect. 
+   - For some redstone components: 
+   - Pistons can be budded by being unable to extend upon being powered, or when retracting into a powered position where they cannot extend.
+   - Droppers, Dispensers, and pistons can be budded by Quasi Connectivity.
+   - Powered rails and activator rails can become budded due to their circumstances of deciding when they are no longer powered.
+   - In the case of a piston pushing what was powering it, before the piston finishing extending.
+   - Rails may be budded for which direction or slope they need to be, specifically with moving rails around.
+   - For all redstone component that react to received power:
+   - By moving or removing a detector rail into/out of a location where it would power something through the block it's on, as that does not send non adjacent updates so long as it doesn't change powered state.
+   - By powered redstone dust changing its direction, making redstone components budded by the direction change sending no block updates.
+   - By a target block reaching a destination after having a tile tick sending no updates on reaching the destination going into a location where it would be powered by redstone dust, ect. 
 
 2. For solely state updates:
-- Observers, from the face, will react to them.
-- LUDs featuring waterlogged blocks
-- Falling block floating setups, such as ones made from how a sticky piston failing to retract a slime structure sends no updates.
-- Scaffolding which hasn't realized it's on an observer or target block due to them being moved after reaching a destination sending no updates.
+   - Observers, from the face, will react to them.
+   - LUDs featuring waterlogged blocks
+   - Falling block floating setups, such as ones made from how a sticky piston failing to retract a slime structure sends no updates.
+   - Scaffolding which hasn't realized it's on an observer or target block due to them being moved after reaching a destination sending no updates.
 
 3. For block updates and state updates:
-- LUDs not featuring waterlogged blocks react to both of these
-- Floating falling blocks, with 
+   - LUDs not featuring waterlogged blocks react to both of these
+   - Floating falling blocks, with 
 
 4. For comparator updates and block updates:
-- Chests being locked so a comparator can no longer read them, either by a solid block on top or some blocks, such as cauldrons being removed non adjacently
-- A comparator budded with a general bud technique
-See also:
- https://minecraft.fandom.com/wiki/Tutorials/Comparator_update_detector
+   - Chests being locked so a comparator can no longer read them, either by a solid block on top or some blocks, such as cauldrons being removed non adjacently
+   - A comparator budded with a general bud technique
+## See also:
+[https://minecraft.fandom.com/wiki/Tutorials/Comparator_update_detector](https://minecraft.fandom.com/wiki/Tutorials/Comparator_update_detector)

--- a/GameMechanics/ChunkLoading.md
+++ b/GameMechanics/ChunkLoading.md
@@ -10,8 +10,8 @@ todo
 ## 1.14+ chunkloading
 Chunk loading in 1.14 was changed drastically and many ways of chunk loading where changed, in 1.14+ the only way to entity load a chunk is with a player or bot, a portal, the spawn, or the ender dragon fight.
 As it's not possible to promote border loaded chunks to entity ticking, remote chunkloading is very limited:
-- https://www.youtube.com/watch?v=5aZ66IWD6ZY
-- https://www.youtube.com/watch?v=P3T3Q83LkTM
+- [https://www.youtube.com/watch?v=5aZ66IWD6ZY](https://www.youtube.com/watch?v=5aZ66IWD6ZY)
+- [https://www.youtube.com/watch?v=P3T3Q83LkTM](https://www.youtube.com/watch?v=P3T3Q83LkTM)
 - Or a nether portal line
 
 The spawn chunks where also expanded, it is also worth noting that mobs will now despawn in lazy chunks which removes lazy looting from the game for any mobs that do no have the persistence tag.

--- a/GameMechanics/ComparatorSignalStrength.md
+++ b/GameMechanics/ComparatorSignalStrength.md
@@ -6,36 +6,34 @@ description: Mechanics of the comparator related to signal strenth
 # comparator signal strength
 
 The redstone comparator is a block which can maipulate signal strength outputs from other redstone components, certain blocks, and item frames.
-- Normal Containers
-For normal containers, the output of a comparator is governed by a simple equation:
-Let I be the size of the inventory, 
-i be the slot in the inventory, 
-C be the number of items in the stack, 
-S be the stack size (1, 16, or 64), and 
-I_N be the number of slots in the inventory such that the C for that slot is non-zero. Assume that S for an empty slot is 1.
-![enter image description here](https://i.imgur.com/1saTFkJ.png)
-Note that C can be on the domain [1,127] regardless of the stack size. For this reason, it is possible to achieve signal strengths greater than 15 in 1.12 survival using stacked shulker boxes. All stacked boxes acquired in older versions will still be stacked if the world is updated to a newer version, however stacking boxes in newer versions is no longer possible without the assistance of mods or duping exploits.
-Since no other redstone component can directly transmit a signal strength greater than 15, the raw transmission of these signals is therefore confined to the x-z plane.
-Comparators cannot read from chests with solid blocks directly above them. If the block is placed or removed, it will still retain its state until updated.
-The list of normal containers and their inventory sizes are as follows:
-Furnace, Blast Furnace, Smoker: 3
-Hopper, Brewing Stand*: 5
-Dropper, Dispenser: 9
-Chest, Trapped Chest, Barrel, Shulker Box: 27
-Double Chest, Double Trapped Chest: 54
-The number of slots in a brewing stand was changed from 4 to 5 in the 1.9 release with the addition of the blaze powder mechanic.
 
-- Other Sources
+## Normal Containers
+For normal containers, the output of a comparator is governed by a simple equation:  
+Let I be the size of the inventory,  
+i be the slot in the inventory,  
+C be the number of items in the stack,  
+S be the stack size (1, 16, or 64), and  
+I_N be the number of slots in the inventory such that the C for that slot is non-zero. Assume that S for an empty slot is 1.
+![comparator output formula](https://i.imgur.com/1saTFkJ.png)
+Note that C can be on the domain [1,127] regardless of the stack size. For this reason, it is possible to achieve signal strengths greater than 15 in 1.12 survival using stacked unstackable items, such as shulker boxes. All stacked boxes acquired in older versions will still be stacked if the world is updated to a newer version, however stacking boxes in newer versions is no longer possible without the assistance of mods or duping exploits.  
+Since no other redstone component can directly transmit a signal strength greater than 15, the raw transmission of these signals is therefore confined to the x-z plane.  
+Comparators cannot read from chests with solid blocks directly above them. If the block is placed or removed, it will still retain its state until updated.
+The list of normal containers and their inventory sizes are as follows:  
+|Block|Inventory size|
+|---|---|
+|Furnace, Blast Furnace, Smoker|3|
+|Hopper, Brewing Stand*|5|
+|Dropper, Dispenser|9|
+|Chest, Trapped Chest, Barrel, Shulker Box|27|
+|Double Chest, Double Trapped Chest|54|
+*The number of slots in a brewing stand was changed from 4 to 5 in the 1.9 release with the addition of the blaze powder mechanic.
+
+## Other Sources
 Comparators can read signal strengths from other blocks, but use different rules for calculating the signal strength output for each one.
 
 1. Command Blocks
-Comparators will use the value of the 
-SuccessCount
- tag directly. This tag is responsible for tracking the number of successful executions for the command it is currently set to hold. However, this value can be directly modified by using commands (
-`/blockdata <x> <y> <z> {SuccessCount:<value>}`
-for 1.8 - 1.12 and
-`/data modify block <x> <y> <z> SuccessCount set value <value>`
-for 1.13 and above).
+Comparators will use the value of the `SuccessCount` tag directly. This tag is responsible for tracking the number of successful executions for the command it is currently set to hold.  
+However, this value can be directly modified by using commands (`/blockdata <x> <y> <z> {SuccessCount:<value>}` for 1.8 - 1.12 and `/data modify block <x> <y> <z> SuccessCount set value <value>` for 1.13 and above).
 
 2. Detector Rails
 Comparators reading from detector rails will output a signal strength according to the equation in 
@@ -45,41 +43,49 @@ Normal Containers
 If there are multiple of these types of minecarts on the detector rail, the oldest one takes priority. All other minecarts have no effect on the output.
 4. Item Frames
 Comparators reading from item frames will output a signal strength based on the rotation of the item in the frame, if any. If there are no items, the comparator will output zero. An item in the frame will change the output to one, and rotating the item will increase the output by one until it returns to the default rotation and resets back to one. The behavior for determining the signal strength for competing sources are different between versions: 
-- pre-1.16: The value from blocks occupying the same space as the item frame always take priority over the item frame. Changing the signal strength output of the block without sending a comparator update (e.g. dispensing water, moving an open trapdoor, locking a chest with a solid block, etc.) will cause the comparator to retain its state until updated as described in the Normal Containers section. This effectively creates a dual-edge comparator update detector.
-- post-1.16: The comparator will take the maximum value from any input which is not a redstone component, unless said redstone component is powered to signal strength 15 or above. Changing the maximum value without sending a comparator update (e.g. locking a chest with a solid block) will cause the comparator to retain its state until updated as described in the Normal Containers section similar to the pre-1.16 behavior.
+   - pre-1.16: The value from blocks occupying the same space as the item frame always take priority over the item frame. Changing the signal strength output of the block without sending a comparator update (e.g. dispensing water, moving an open trapdoor, locking a chest with a solid block, etc.) will cause the comparator to retain its state until updated as described in the Normal Containers section. This effectively creates a dual-edge comparator update detector.
+   - post-1.16: The comparator will take the maximum value from any input which is not a redstone component, unless said redstone component is powered to signal strength 15 or above. Changing the maximum value without sending a comparator update (e.g. locking a chest with a solid block) will cause the comparator to retain its state until updated as described in the Normal Containers section similar to the pre-1.16 behavior.
 5. Jukeboxes
-If a disc is inserted into the juke box, it will output a unique signal strength depending on which disc is stored in it:
-13 cat blocks chirp far mall mellohi stal strad ward
-11 wait pigstep (post-1.16 only).
-The signal strength is retained regardless of whether the song is still playing.
+If a disc is inserted into the juke box, it will output a unique signal strength depending on which disc is stored in it. The signal strength is retained regardless of whether the song is still playing.  
+The list is as follows:
+   1. 13
+   2. cat
+   3. blocks
+   4. chirp
+   5. far
+   6. mall
+   7. mellohi
+   8. stal
+   9. strad
+   10. ward
+   11. 11
+   12. wait
+   13. pigstep (post-1.16 only)
+   14. otherside (post-1.18 only)
 6. Cakes
-A cake has a maximum value of 14, but decreases by two levels for each bite consumed (i.e. signal_strength = 14 - 2 * #bites).
+A cake has a maximum value of 14, but decreases by two levels for each bite consumed (i.e. `signal_strength = 14 - 2 * #bites`).
 7. Cauldrons
-With water or snow*, the output represents the fill level, which can be in the range 
-[0,3]
-. Lava cauldrons will always output one (post-1.17 only).
+With water or snow*, the output represents the fill level, which can be in the range [0,3]. Lava cauldrons will always output one (post-1.17 only).
 8. Composters
-The output represents the fill level, which can be in the range 
-[0,8]. Note that level 7 is unstable and will transition to level 8 after exactly one second (20 game ticks) after level 7 was reached.
+The output represents the fill level, which can be in the range [0,8]. Note that level 7 is unstable and will transition to level 8 after exactly one second (20 game ticks) after level 7 was reached.
 9. Lecterns
-The output represents which page the book is on as a fraction of 15, where the first page is 0 and the last is 15. The signal strength is precisely (page_index/max(1,total_pages-1)) * 15.
+The output represents which page the book is on as a fraction of 15, where the first page is 0 and the last is 15. The signal strength is precisely `(page_index/max(1,total_pages-1)) * 15`.
 10. Beehives/Bee Nests
 The output represents the fill level, which can be in the range [0,5].
 11. Respawn Anchors
-The output is max(0,4*#charges-1).
+The output is `max(0,4*#charges-1)`.
 12. Skulk Sensors
 Comparators will output a different signal according to which sound the sensor detected. The current values are not yet final, so they will not be listed here.
 13. Other Redstone Components
 Comparators will preserve whatever signal strength is given as input.
+
 ## Comparator Mechanics
 Given multiple redstone inputs, a comparator will take the one with the maximum signal strength.
-Block-Entity Priority: 
-- pre-1.16: Comparators always prioritize the block.  
-- post-1.16: Comparators prioritize the highest signal strength.
-
-1. Block/Entity-Component Priority: Comparators prioritize Components if and only if their signal strength is 15 or greater.
-2. Component Signal Strength Priority: Comparators will prioritize based on directional update order.
-3. Comparison/Subtraction Priority: Comparators will use the largest of the two side values.
-4. Comparison Logic: Comparators will always output zero if the back input is less than at least one of the side inputs.
-5. Subtraction Logic: Comparators will output according to the rule: 
-out = max(0,in - max(left,right)).
+1. Block-Entity Priority: 
+   - pre-1.16: Comparators always prioritize the block.  
+   - post-1.16: Comparators prioritize the highest signal strength.
+2. Block/Entity-Component Priority: Comparators prioritize Components if and only if their signal strength is 15 or greater.
+3. Component Signal Strength Priority: Comparators will prioritize based on directional update order.
+4. Comparison/Subtraction Priority: Comparators will use the largest of the two side values.
+5. Comparison Logic: Comparators will always output zero if the back input is less than at least one of the side inputs.
+6. Subtraction Logic: Comparators will output according to the rule: `out = max(0,in - max(left,right))`.

--- a/GameMechanics/ComparatorSignalStrength.md
+++ b/GameMechanics/ComparatorSignalStrength.md
@@ -64,7 +64,7 @@ The list is as follows:
    13. pigstep (post-1.16 only)
    14. otherside (post-1.18 only)
 6. Cakes
-A cake has a maximum value of 14, but decreases by two levels for each bite consumed (i.e. `signal_strength = 14 - 2 * #bites`).
+A cake has a maximum value of 14, but decreases by two levels for each bite consumed (i.e. `signal_strength = 14 - 2 * bites_taken`).
 7. Cauldrons
 With water or snow*, the output represents the fill level, which can be in the range [0,3]. Lava cauldrons will always output one (post-1.17 only).
 8. Composters

--- a/GameMechanics/ComparatorSignalStrength.md
+++ b/GameMechanics/ComparatorSignalStrength.md
@@ -70,7 +70,7 @@ With water or snow*, the output represents the fill level, which can be in the r
 8. Composters
 The output represents the fill level, which can be in the range [0,8]. Note that level 7 is unstable and will transition to level 8 after exactly one second (20 game ticks) after level 7 was reached.
 9. Lecterns
-The output represents which page the book is on as a fraction of 15, where the first page is 0 and the last is 15. The signal strength is precisely `(page_index/max(1,total_pages-1)) * 15`.
+The output represents which page the book is on as a fraction of 15, where the first page is 0 and the last is 15. The signal strength is precisely `(page_index / max(1, total_pages - 1)) * 15`.
 10. Beehives/Bee Nests
 The output represents the fill level, which can be in the range [0,5].
 11. Respawn Anchors

--- a/GameMechanics/ComparatorSignalStrength.md
+++ b/GameMechanics/ComparatorSignalStrength.md
@@ -89,4 +89,4 @@ Given multiple redstone inputs, a comparator will take the one with the maximum 
 3. Component Signal Strength Priority: Comparators will prioritize based on directional update order.
 4. Comparison/Subtraction Priority: Comparators will use the largest of the two side values.
 5. Comparison Logic: Comparators will always output zero if the back input is less than at least one of the side inputs.
-6. Subtraction Logic: Comparators will output according to the rule: `out = max(0,in - max(left,right))`.
+6. Subtraction Logic: Comparators will output according to the rule: `out = max(0, in - max(left, right))`.

--- a/GameMechanics/ComparatorSignalStrength.md
+++ b/GameMechanics/ComparatorSignalStrength.md
@@ -26,6 +26,7 @@ The list of normal containers and their inventory sizes are as follows:
 |Dropper, Dispenser|9|
 |Chest, Trapped Chest, Barrel, Shulker Box|27|
 |Double Chest, Double Trapped Chest|54|
+
 *The number of slots in a brewing stand was changed from 4 to 5 in the 1.9 release with the addition of the blaze powder mechanic.
 
 ## Other Sources

--- a/GameMechanics/ComparatorSignalStrength.md
+++ b/GameMechanics/ComparatorSignalStrength.md
@@ -74,7 +74,7 @@ The output represents which page the book is on as a fraction of 15, where the f
 10. Beehives/Bee Nests
 The output represents the fill level, which can be in the range [0,5].
 11. Respawn Anchors
-The output is `max(0,4*#charges-1)`.
+The output is `max(0, 4 * number_of_charges - 1)`.
 12. Skulk Sensors
 Comparators will output a different signal according to which sound the sensor detected. The current values are not yet final, so they will not be listed here.
 13. Other Redstone Components

--- a/GameMechanics/HugeFungi.md
+++ b/GameMechanics/HugeFungi.md
@@ -6,6 +6,7 @@ description: Mechanics of huge fungi generation and farms
 # Huge fungi
 
 Report conducted by ncolyer, with information gathered through code reading, multiple experiments, consultations, discussions, trial and error, and more
+
 ## Overview
 This page will split into the 3 main ways to harvest huge fungi (more commonly referred to as 'Nether Trees', or 'Wart Trees')
 - Manual Harvesting
@@ -13,7 +14,8 @@ This page will split into the 3 main ways to harvest huge fungi (more commonly r
 - Self-Sustaining
 
 Some theorised methods will also be discussed, such as RNG manipulation, and self-sustaining N-Core designs.
-### Glossary:
+
+## Glossary:
 - Rates:
  The farm's collectable item output, normally measured in items per hour
 - Efficiency:
@@ -24,41 +26,49 @@ Some theorised methods will also be discussed, such as RNG manipulation, and sel
 Random Number Generator, can be manipulated using the seed.
 - s: 
 Used in all cases instead of alternative 'z' spelling.
-### Growth Mechanics
+
+## Growth Mechanics
 1. Natural Generation
-Huge fungi generate naturally in only 2 biomes situated in the Nether (DIM-1); the warped forest, where you can find warped huge fungi, and the crimson forest, where you can find crimson huge fungi. Huge fungi only generate naturally in their respective biome. 
-To determine the size of huge fungi, a random integer is chosen between 4 and 13 [inclusive]. There is then a 1/12 chance of that integer doubling. The resulting value is the height of the trunk. A layer of wart blocks and shroomlights, or leaves, is then spread around the trunk, being able to generate up to 3 blocks out from the trunk. There is a 3x3x2 hollow ring that surrounds the lowest block of a fungus tree where no blocks generate.
-![fungi_gen](https://i.imgur.com/8dHv9g5.png)
-Layers 1-3 the leaf diameter (measured as a square) is 3, then at layers 4-17 it's 5 blocks, at layer 18-25 it reverts back to 3 blocks wide, and at layers 26 and 27, it gets reduced again to just 1 block wide.
+Huge fungi generate naturally in only 2 biomes situated in the Nether (DIM-1); the warped forest, where you can find warped huge fungi, and the crimson forest, where you can find crimson huge fungi. Huge fungi only generate naturally in their respective biome.   
+To determine the size of huge fungi, a random integer is chosen between 4 and 13 [inclusive]. There is then a 1/12 chance of that integer doubling. The resulting value is the height of the trunk. A layer of wart blocks and shroomlights, or leaves, is then spread around the trunk, being able to generate up to 3 blocks out from the trunk. There is a 3x3x2 hollow ring that surrounds the lowest block of a fungus tree where no blocks generate.  
+![fungi_gen](https://i.imgur.com/8dHv9g5.png)  
+Layers 1-3 the leaf diameter (measured as a square) is 3, then at layers 4-17 it's 5 blocks, at layer 18-25 it reverts back to 3 blocks wide, and at layers 26 and 27, it gets reduced again to just 1 block wide.  
 2. Player Grown
-If a player bonemeals a fungus, and if that fungus is directly above its respective nylium block (e.g. warped fungus on warped nylium), there will be a 40% chance that it will grow. So if a player bonemeals a fungus 4 times, there will be an 87.04% chance it will grow, (99.998% chance if 20 attempts are made).
-Note: A fungus plant (the 'sapling' of huge fungi), will not grow by itself through random ticks, unlike traditional saplings.
-When a fungus grows, it doesn't check for blocks above or around it, this allows for pistons to be situated adjacent to the trunk, allowing for extremely fast cycle speeds.
-Note: That a fungus will not grow if it is obscured by the height limit or if it is placed outside of the world.
+If a player bonemeals a fungus, and if that fungus is directly above its respective nylium block (e.g. warped fungus on warped nylium), there will be a 40% chance that it will grow. So if a player bonemeals a fungus 4 times, there will be an 87.04% chance it will grow, (99.998% chance if 20 attempts are made).  
+Note: A fungus plant (the 'sapling' of huge fungi), will not grow by itself through random ticks, unlike traditional saplings.  
+When a fungus grows, it doesn't check for blocks above or around it, this allows for pistons to be situated adjacent to the trunk, allowing for extremely fast cycle speeds.  
+Note: That a fungus will not grow if it is obscured by the height limit or if it is placed outside of the world.  
 3. Dispenser Grown
-Similarly, if bonemeal is placed inside of a dispenser, and then that dispenser is pointing into a fungus plant on its respective nylium block, then there will also be a 40% chance of it growing per attempt. Dispensers can be used to automatically grow the fungus plant, and up to 5 can surround a fungus plant, allowing for fungi to grow at 5hz on average. 
-Note: There is no diminish in return with bonemeal efficiency, and dispensers used.
-### Block Properties
+Similarly, if bonemeal is placed inside of a dispenser, and then that dispenser is pointing into a fungus plant on its respective nylium block, then there will also be a 40% chance of it growing per attempt. Dispensers can be used to automatically grow the fungus plant, and up to 5 can surround a fungus plant, allowing for fungi to grow at 5hz on average.  
+Note: There is no diminish in return with bonemeal efficiency, and dispensers used.  
+
+## Block Properties
 A table showing the various blocks that are heavily involved in a Huge Fungi Farm:
 ![fungi_table](https://i.imgur.com/rQrmRej.png)
-### Harvesting Methods
+
+## Harvesting Methods
 There are a multitude of ways in which huge fungi can be farmed, here are some of the more common and technical methods.
-#### Manual Harvesting
+
+### Manual Harvesting
 During the early game where redstone resources are limited, certain manual harvesting methods are utilised. While it is recommended that a player gathers resources to make a farm, rather than spending that time manually farming, certain manual harvesting methods have arisen.
-#### Nether Exploration
+
+### Nether Exploration
 Collecting huge fungi blocks in their own biomes is a great way to collect a sufficient amount of wood and decorative blocks early game. 
 The fastest way to use this method is to make an efficiency 5 netherite axe and hoe, then travel to the nether and fly around using an elytra until you come across a warped or crimson forest. If it's a crimson forest, be sure to bring warped fungus to repel hoglins (must be planted, with an area of effect of 15 blocks). 
 After planting a fungus, build a 3x3 platform of gold blocks with a beacon on top for the haste 1 effect. Fly up from the beacon base and destroy the netherrack obstructing the beacon beam. The haste 1 effect, will reduce the mining time per stem block by 2gt [check]. This will also help when mining wart blocks and shroomlights, as when combined with an efficiency 3 netherite or diamond hoe, you will be able to mine each block in 1gt [check]. Setting up and removing a 1 layer beacon in the nether takes on average 600gt, so this beacon method will only be effective if you are mining more than 300 stem blocks, or if it is necessary for instant mining more than 38 blocks. 
 Once the beacon is set up, you can begin harvesting trees. Huge Fungi normally generate together in clumps, so it's best to climb to the top using twisting vines, and then mine from the top down. Be sure to use a hoe to mine the leaf blocks (wart blocks and shroomlights), and your axe to harvest the stems.
 ![fungi_harvesting](https://i.imgur.com/Vk8g6bi.png)
 To marginally increase speed, carry with you a few shulker boxes of unbreaking 3, efficiency 5, gold axes to reduce the mining speed by 1gt per stem block. 
-#### Greenhouse
+
+### Greenhouse
 Place 2 nylium in a 3x3 grid pattern with 6 blocks in between each one. Then construct a water stream platform beneath it. Have the water stream funnel the items into a chest storage, connected by a hopper. To use the manual farm, place down a fungus on each nylium block, then grow the fungi using bonemeal. Now climb to the top using ladders, a bubble column, scaffolding or vines, and mine out the huge fungi from the top down. After harvesting the huge fungi, collect any items that didn't drop into the water stream below. 
 ![fungi_greenhouse](https://i.imgur.com/wUlpwwM.png)
-#### Block Chamber/Storage
+
+### Block Chamber/Storage
 Build a traditional semi-automatic huge fungi farm, and connect the block stream to a block chamber. When you would like to harvest the blocks, climb to the top of the storage and mine them out using haste 2 and an efficiency 5 netherite axe and hoe.
-https://www.youtube.com/watch?v=jytLCfRu_54
-#### Semi-Automatic
+[https://www.youtube.com/watch?v=jytLCfRu_54](https://www.youtube.com/watch?v=jytLCfRu_54)
+
+### Semi-Automatic
 Semi-Automatic harvesting is when everything in a farm is self-sufficient except for the input. 
 In the case of semi-automatic huge fungi farms, this would be the placement of fungi plants and often, but not always, supplying it with bonemeal.
 - Positives:
@@ -66,23 +76,22 @@ In the case of semi-automatic huge fungi farms, this would be the placement of f
 - Negatives: 
 Usually quite block inefficient, consumes high amounts of bonemeal, high-frequency designs can be locational and directional
 1. Single Core
-1 nylium, slow rates, average efficiency.
-https://www.youtube.com/watch?v=yY64bj2DjhA
-https://www.youtube.com/watch?v=nlfAwEV-cCk
+   1 nylium, slow rates, average efficiency.  
+   [https://www.youtube.com/watch?v=yY64bj2DjhA](https://www.youtube.com/watch?v=yY64bj2DjhA)
+   [https://www.youtube.com/watch?v=nlfAwEV-cCk](https://www.youtube.com/watch?v=nlfAwEV-cCk)
 2. Dual Core
-2 nylium, average rates, low efficiency.
-https://www.youtube.com/watch?v=XAIsjTTGpPA
- (outdated)
-https://www.youtube.com/watch?v=yY64bj2DjhA
+   2 nylium, average rates, low efficiency.  
+   [https://www.youtube.com/watch?v=XAIsjTTGpPA](https://www.youtube.com/watch?v=XAIsjTTGpPA) (outdated)
+   [https://www.youtube.com/watch?v=yY64bj2DjhA](https://www.youtube.com/watch?v=yY64bj2DjhA)
 3. Quad-Core
-4 nylium, fast rates, low efficiency.
-https://www.youtube.com/watch?v=rhncko7vKLs
+   4 nylium, fast rates, low efficiency.  
+   [https://www.youtube.com/watch?v=rhncko7vKLs](https://www.youtube.com/watch?v=rhncko7vKLs)
 4. N-Core
-A farm consisting of N-modules connected by a sufficient transportation system. Extremely fast rates, maxing out at 5,400,000/h with an auto-clicker (20hz) and around 1,400,000/h at vanilla placement speed (5hz), high efficiency.
-https://www.youtube.com/watch?v=rhncko7vKLs
-https://youtu.be/nMkffHVLHvw
- (ongoing)
-#### Self-Sustaining
+   A farm consisting of N-modules connected by a sufficient transportation system. Extremely fast rates, maxing out at 5,400,000/h with an auto-clicker (20hz) and around 1,400,000/h at vanilla placement speed (5hz), high efficiency.  
+   [https://www.youtube.com/watch?v=rhncko7vKLs](https://www.youtube.com/watch?v=rhncko7vKLs)
+   [https://youtu.be/nMkffHVLHvw](https://youtu.be/nMkffHVLHvw) (ongoing)
+
+### Self-Sustaining
 Once built, a Self-Sustaining Huge Fungi Farm can run without player interaction as long as it is kept loaded.
 - Positives: 
 Can run in loaded chunks without the need for a player to plant any fungus, can generate a surplus of bonemeal
@@ -90,24 +99,24 @@ Can run in loaded chunks without the need for a player to plant any fungus, can 
  Slow, more expensive to build, laggy, and limited (if any) wart blocks and shroomlights are produced, often unreliable.
  
 1. Growing Area
-Max 5x5 area of nylium to grow fungus plants using bonemeal.
-Flying Machine
-Flying Machine pushing into a TNT dropping zone.
-
-https://www.youtube.com/watch?v=dEToZ4wLuqY
+   Max 5x5 area of nylium to grow fungus plants using bonemeal.  
+   Flying Machine  
+   Flying Machine pushing into a TNT dropping zone.  
+   [https://www.youtube.com/watch?v=dEToZ4wLuqY](https://www.youtube.com/watch?v=dEToZ4wLuqY)
 
 2. Blast Chamber
-Directly Above, Piston wall pushing to external
-
-https://www.youtube.com/watch?v=M51sTIwDo5w
+   Directly Above, Piston wall pushing to external
+   [https://www.youtube.com/watch?v=M51sTIwDo5w](https://www.youtube.com/watch?v=M51sTIwDo5w)
 
 3. N-Core
-Theoretically, the fastest way to harvest huge fungi 
-#### RNG Huge Fungus Farming
+   Theoretically, the fastest way to harvest huge fungi 
+
+### RNG Huge Fungus Farming
 Manipulate RNG to generate a 5x5 platform of fungus, which all grow on the first bonemeal attempt to produce the largest huge fungi possible (7x7x27)
-#### Fungus Farming
+
+### Fungus Farming
 The collection of fungus plants to grow in a huge fungi farm
 
 Dissection of nether foliage distribution:
 
-https://www.youtube.com/watch?v=SOcY9En4l_E
+[https://www.youtube.com/watch?v=SOcY9En4l_E](https://www.youtube.com/watch?v=SOcY9En4l_E)

--- a/GameTick.md
+++ b/GameTick.md
@@ -56,6 +56,7 @@ This method is called in `MinecraftServer.tick()`
 ## ServerWorld.tick()
 `net.minecraft.server.ServerWorld.tick`
 This method is called in `MinecraftServer.tickWorlds()`
+The following actions/processes are performed during every tick:
 ### Tick world Border
 ### Weather:
 - Rain

--- a/GameTick.md
+++ b/GameTick.md
@@ -55,7 +55,7 @@ This method is called in `MinecraftServer.tick()`
 
 ## ServerWorld.tick()
 `net.minecraft.server.ServerWorld.tick`
-This method is called in `MinecraftServer.tickWorlds()`
+This method is called in `MinecraftServer.tickWorlds()`  
 The following actions/processes are performed during every tick:
 ### Tick world Border
 ### Weather:

--- a/GameTick.md
+++ b/GameTick.md
@@ -8,7 +8,7 @@ description: All the information about the tick phases
 
 A tick is a part of the game loop where the game logic is processed.
 Many different things are done in a tick, and some of them a grouped in "tick phases."
-The ones commonly used for redstone are theses:
+The ones commonly used for redstone are these:
 
 1. Block/fluid tile ticks
 2. chunkManager tick
@@ -27,7 +27,8 @@ The main loop:
 - If the server is running, check if the server can keep up (<=50mspt), and if it can't (>50mspt) log a warning.
 - Create a new tick monitor
 - Start the tick
-- Call `net.minecraft.server.MinecraftServer.tick`Wait for the next tick
+- Call `net.minecraft.server.MinecraftServer.tick`
+- Wait for the next tick
 - End the tick and stop the tick monitor
 
 If an exception occurs this loop will shut down the server and try to create and save a crash report.
@@ -35,12 +36,13 @@ If an exception occurs this loop will shut down the server and try to create and
 `net.minecraft.server.MinecraftServer.tick`
 This method is called in `runServer()`
 ### Basic tick initialization:
-Increase the number of ticks by one
-Get the time of the start of the tick
-Call `net.minecraft.server.MinecraftServer.tickWorlds`Player managing
-Autosave if the tick number is divisible by 6000
-Update snooper if tick number is divisible by 6000
-Calculate length of tick in milliseconds
+- Increase the number of ticks by one
+- Get the time of the start of the tick
+- Call `net.minecraft.server.MinecraftServer.tickWorlds`
+- Player managing
+- Autosave if the tick number is divisible by 6000
+- Update snooper if tick number is divisible by 6000
+- Calculate length of tick in milliseconds
 ### tickWorlds()
 `net.minecraft.server.MinecraftServer.tickWorlds`
 This method is called in `MinecraftServer.tick()`
@@ -51,109 +53,115 @@ This method is called in `MinecraftServer.tick()`
 - Update player latency
 - Refresh server GUI
 
-### ServerWorld.tick()
+## ServerWorld.tick()
 `net.minecraft.server.ServerWorld.tick`
 This method is called in `MinecraftServer.tickWorlds()`
-#### Tick world Border
-#### Weather:
-- - Rain
-- - Thunder
-#### Player sleeping
-#### Chunks:
+### Tick world Border
+### Weather:
+- Rain
+- Thunder
+### Player sleeping
+### Chunks:
 - Purge unloaded chunks
 - TACS stuff (?)
 - Update chunk load levels
 - Natural mob spawning
-- Mob spawning by ticking spawners
+- Mob spawning by ticking spawners  
 - Random ticks
 - Player movement
 - Write POIs
 - Unload chunks
 - Initialize chunk cache
 - World Border`net.minecraft.world.border.WorldBorder.tick` is called in the game loop. The only thing that will happen during this "ticking" of the world border is checking if the world border needs to change in size, and executing that.
-- Weather Cycle: TODO:move to a separate article
-In the weather section of the tick function there are 6 variable allocations.
-The first one is a variable you get from a function that decides if it’s raining or not from rain gradient (the sky colour, but more later on this). The other variables are clearWeatherTime, rainTime, thunderTime, isRaining and isThundering from the world properties.
-The first part of the code is an if block that checks if `clearWeatherTime` is bigger than 0. This part is basically a hackfix to make it so that the weather will stay clear for a certain amount of time when the `/weather clear [time]` command is used. In this block `clearWeatherTime` will count down. After this `thunderTime` and `rainTime` will be set to 1 if it’s not thundering or raining respectively. If it is thundering or raining they will be set to 0. After this `thundering` and `raining` will be set to false in the properties.
-What this accomplishes will be that once `clearWeatherTime` has reached 0, it will start raining and thundering the next tick.
-If `clearWeatherTime` isn’t bigger than 0, `thunderTime` and `rainTime` will be checked.
-If `thunderTime` is bigger than 0 we’ll check if `thunderTime - 1` is equal to 0. If that is the case, then `thundering` will be reversed. This means if it was thundering, it will stop thundering and if it wasn’t thundering it will start thundering.
-If however `thunderTime` isn’t bigger than 0, a new value is set for thunder time. This value is decided by:
-thunderTime = thundering ? this.random.nextInt(12000) + 3600 : this.random.nextInt(168000) + 12000;
-In a more readable format, this will mean that:
-If it is thundering, the new `thunderTime`  will be between 3 600 and 15 600.
-If it is not thundering, the new `thunderTime`  will be between 12 000 and 180 000.
-Which value somewhere in this range it becomes is determined by a random factor.
-The same process happens for `rainTime`, though the new value for `rainTime` is determined differently:
-rainTime = propertiesRaining ? this.random.nextInt(12000) + 12000 : this.random.nextInt(168000) + 12000;
-In a more readable format, this will mean that:
-If it is thundering, the new `rainTime` will be between 12 000 and 24 000.
-If it is not thundering, the new `rainTime` will be between 12 000 and 180 000.
-Which value somewhere in this range it becomes is determined by a random factor.
-After this the values that were changed will be reallocated to the corresponding fields.
-So now for the explanation of how this actually works. The way in which this works is a little confusing 
-`clearWeatherTime` isn’t used to determine how long the weather will stay clear outside of commands. Instead what happens is:
-The game starts and `clearWeatherTime`, `rainTime` and `thunderTime` are set to 0. `raining` and `thundering`  are set to false. Now, since everything is set to 0 it will immediately go to the part where it sets the timers, using the formulas we’ve just seen. In this case `rainTime` and `thunderTime` will be used to indicate how long it will **not** be raining or thundering. Both timers will count down, and only when they have reached 0 it will start raining or thundering, depending on which timer ran out. It will start this weather by flipping the boolean as we’ve seen before. After this a new time will be set for `rainTime` or `thunderTime`. This time, they’ll be used to indicate how long it will be raining or thundering. By constantly flipping the time `rainTime` and `thunderTime` represent, there’s no need to use `clearWeatherTime`. Thus we only have a value for this if we want to force the game to keep the weather clear for a certain amount of time no matter what.
-#### Tile tick phase
+- Weather Cycle: TODO:move to a separate article.  
+  In the weather section of the tick function there are 6 variable allocations.  
+  The first one is a variable you get from a function that decides if it’s raining or not from rain gradient (the sky colour, but more later on this). The other variables are clearWeatherTime, rainTime, thunderTime, isRaining and isThundering from the world properties.  
+  The first part of the code is an if block that checks if `clearWeatherTime` is bigger than 0. This part is basically a hackfix to make it so that the weather will stay clear for a certain amount of time when the `/weather clear [time]` command is used. In this block `clearWeatherTime` will count down. After this `thunderTime` and `rainTime` will be set to 1 if it’s not thundering or raining respectively. If it is thundering or raining they will be set to 0. After this `thundering` and `raining` will be set to false in the properties.  
+  What this accomplishes will be that once `clearWeatherTime` has reached 0, it will start raining and thundering the next tick.  
+  - If `clearWeatherTime` isn’t bigger than 0, `thunderTime` and `rainTime` will be checked.  
+  - If `thunderTime` is bigger than 0 we’ll check if `thunderTime - 1` is equal to 0. If that is the case, then `thundering` will be reversed. This means if it was thundering, it will stop thundering and if it wasn’t thundering it will start thundering.  
+  - If however `thunderTime` isn’t bigger than 0, a new value is set for thunder time.
+
+  This value is decided by:  
+  `thunderTime = thundering ? this.random.nextInt(12000) + 3600 : this.random.nextInt(168000) + 12000;`  
+  In a more readable format, this will mean that:  
+  - If it is thundering, the new `thunderTime`  will be between 3 600 and 15 600.  
+  - If it is not thundering, the new `thunderTime`  will be between 12 000 and 180 000.  
+  
+  Which value somewhere in this range it becomes is determined by a random factor.  
+  The same process happens for `rainTime`, though the new value for `rainTime` is determined differently:  
+  `rainTime = propertiesRaining ? this.random.nextInt(12000) + 12000 : this.random.nextInt(168000) + 12000;`  
+  In a more readable format, this will mean that:  
+  - If it is thundering, the new `rainTime` will be between 12 000 and 24 000.  
+  - If it is not thundering, the new `rainTime` will be between 12 000 and 180 000.  
+  
+  Which value somewhere in this range it becomes is determined by a random factor.  
+  After this the values that were changed will be reallocated to the corresponding fields.  
+  So now for the explanation of how this actually works. The way in which this works is a little confusing.  
+  `clearWeatherTime` isn’t used to determine how long the weather will stay clear outside of commands. Instead what happens is:  
+  The game starts and `clearWeatherTime`, `rainTime` and `thunderTime` are set to 0. `raining` and `thundering`  are set to false. Now, since everything is set to 0 it will immediately go to the part where it sets the timers, using the formulas we’ve just seen. In this case `rainTime` and `thunderTime` will be used to indicate how long it will **not** be raining or thundering. Both timers will count down, and only when they have reached 0 it will start raining or thundering, depending on which timer ran out. It will start this weather by flipping the boolean as we’ve seen before. After this a new time will be set for `rainTime` or `thunderTime`. This time, they’ll be used to indicate how long it will be raining or thundering. By constantly flipping the time `rainTime` and `thunderTime` represent, there’s no need to use `clearWeatherTime`. Thus we only have a value for this if we want to force the game to keep the weather clear for a certain amount of time no matter what.  
+
+
+
+### Tile tick phase
 Tile ticks are processed in this phase. The game select tile ticks which have their processing tick (current tick when scheduled+ delay)  smaller or equal to the current tick.
 
-maximum 65536 tile ticks can be processed per tick,if there is more to process,the last tile tick will be delayed to the next tick
+Maximum 65536 tile ticks can be processed per tick,if there is more to process,the last tile tick will be delayed to the next tick.
 Block tileticks an fluid tileticks are proecessed one after the other,with each their own tile tick cap.
 
 
 
-#### Handle raids
+### Handle raids
 
-Chunk Manager tick
-(just before block events since 1.17.1, was before tileticks)
+Chunk Manager tick (just before block events since 1.17.1, was before tileticks).
 
--Handle chunk loading and unloading tickets
--send chunk packets like block changes 
--Do natural mob spawning
--Mob spawning by ticking spawners
--Handle lightning, ice and snow
--Do random ticks
--Player movement
--Tick POI’s
--Unload chunks
--Initialize chunk cache
-
+- Handle chunk loading and unloading tickets
+- Send chunk packets like block changes 
+- Do natural mob spawning
+- Mob spawning by ticking spawners
+- Handle lightning, ice and snow
+- Do random ticks
+- Player movement
+- Tick POI’s
+- Unload chunks
+- Initialize chunk cache
 
 
-#### Block event phase
+
+### Block event phase
 Block events are processed in this phase. This includes things such as:
 
-- piston extension/retraction
-- noteblock play note
-- chest/endercher/shulker open/close (change open count)
-- bell updating villagers when hit
-- gateway start cooldown
-- mobspawner reset delay
+- Piston extension/retraction
+- Noteblock play note
+- Chest/endercher/shulker open/close (change open count)
+- Bell updating villagers when hit
+- Gateway start cooldown
+- Mobspawner reset delay
 
 Block events are stored in a LinkedHashSet. The game loops through block events and processes them. Piston block events can activate and schedule another block event that is added a the end of the LinkedHashSet.This allow chaining multiple blockevents in the same tick.
 
 Blockevents are sent directly to the client the execute them also clientside.
 
-#### Handle ender dragon fight
+### Handle ender dragon fight
 
-#### Regular entity phase
+### Regular entity phase
 Regular entities are processed in this phase. This includes things such as:
-- entities move
-- entities trigger tripwire hooks
-- entities trigger pressure plates.
-#### Tile entity phase
+- Entities move
+- Entities trigger tripwire hooks
+- Entities trigger pressure plates.
+### Tile entity phase
 Tile/Block entities are processed in this phase. This includes things such as:
-- moving blocks turn into normal blocks
-- moving blocks push entities and slime give velocity
-- furnaces check for items in their inventory
-- hoppers push and pull items
-- sculk sensors activate.
-#### Player inputs phase
+- Moving blocks turn into normal blocks
+- Moving blocks push entities and slime give velocity
+- Furnaces check for items in their inventory
+- Hoppers push and pull items
+- Sculk sensors activate.
+### Player inputs phase
 Player inputs are processed in this phase. This includes things such as:
-- flipping levers
-- pushing buttons
-- placing blocks
-- breaking blocks
+- Flipping levers
+- Pushing buttons
+- Placing blocks
+- Breaking blocks
 
 ## Other Things Calculated In A tick
 There are other things that are calculated in a ticks that isnt specific to a phase, for example rails and redstone dust is calculated recursivly independent from the ticks and can happen in all of them. These components are called "recursive updators" or "instant updators".

--- a/GameTick/BlockTicks.md
+++ b/GameTick/BlockTicks.md
@@ -5,28 +5,27 @@ description: What happen in tile tick phase?
 
 # tile ticks
 
-Tile ticks are action sheduled to happen in a given number of ticks at a block.
-When the tile tick is executed,the block execute an action depending on its type.
+Tile ticks are actions sheduled to happen in a given number of ticks at a block.
+When the tile tick is executed, the block executes an action depending on its type.
 
 ## Tile tick phase
-In this phase the game select tile ticks which have their processing tick (current tick number(world counter) when scheduled+ delay)  smaller or equal to the current tick,and move them in a different list, then they are executed. Some redstone components such as observers and lamps doesn't check if there is a tiletick in the executing list before scheduling a new one:
-https://bugs.mojang.com/browse/MC-189954
-https://bugs.mojang.com/browse/MC-189954
+In this phase the game selects scheduled tile ticks which have their processing tick (the result of taking the tick number(world counter) from the tick the update was scheduled in + the delay of the tile tick) smaller than or equal to the current tick, and move them to a different list, where they are executed. Some redstone components such as observers and lamps doesn't check if there is a tiletick in the executing list before scheduling a new one:  
+[[MC-189954] Observers react to updates if they already have a scheduled tick](https://bugs.mojang.com/browse/MC-189954).
 
-There is two scheduler for block tile ticks then fluid tile ticks.
+There are two different schedulers that get processed after one another: block tile ticks, then fluid tile ticks.
 ### Tile tick cap:
-A maximun of 65536 tile ticks can execute in one tick,the tile ticks that weren't executed are delayed to the next tick
+A maximun of 65536 tile ticks can execute in one tick. The tile ticks that weren't executed in the tick they were supposed to are delayed to the next tick.
 
 ### Player input bug:
-Player input are executed after the block event phase and before the world counter increment,so if a player input create a tile tick,it will schedule a tile tick starting from a tick, and execute the block event phase only in the next tick.
-If the player inputs start at the end of a tick or at the beginning of the next tick is not really defined,because it depends where you split ticks
-If you consider that a the player input phase happen at the begining of a tick,then tiles tick scheduled by a player input lose 1 gametick of delay
-If you consider that a the player input phase happen at the end of a tick,then blockevents created by a player input will execute(extend a piston for example) only in the next tick
+Player input are executed after the block event phase and before the world counter increment, so if a player input creates a tile tick, it will schedule a tile tick starting from the current tick, and execute the block event phase only in the next tick.
+Whether the player inputs start at the end of a tick or at the beginning of the next tick is not really defined, because it depends where you split ticks.
+If you consider that a the player input phase happens at the begining of a tick, then tiles tick scheduled by a player input lose 1 gametick of delay.
+If you consider that a the player input phase happen at the end of a tick, then blockevents created by a player input will execute(extend a piston for example) only in the next tick.
 
 ### Tile tick priority:
-A tile tick have a priority,if some tile ticks are executed in the next tick,the tile tick with the higher priority->lower value will execute first
+A tile tick have a priority. If multiple tile ticks are scheduled to be executed, the tile tick with the higher priority (lower value) will execute first.
 | Name | Delay |
-|--|--|--|
+|--|--|
 | Redstone Torch | 2 |
 | Observer | 2 |
 | Dispenser | 4 |

--- a/Other/OlderVersions.md
+++ b/Other/OlderVersions.md
@@ -1,17 +1,13 @@
 ---
 title: Older versions
 description: Mechanics Changes between Versions
+---
 
 # older versions
 
 Why do people play non-latest versions?
-If you are new to technical Minecraft you will probably find yourself wondering, why does the machine I saw on Scicraft not work on my [insert latest version] world? The reason itself is really quite simple, 
-Scicraft is not running [insert latest version], they run 1.12.2.
- As well, contrary to popular belief, 
-there are other technical servers
-, and to top it all off, 
-many of those also run 1.12.x
-, with some even running more obscure versions including 1.7.2, 1.8.1, 1.13.1, 1.15.2, and more.
+If you are new to technical Minecraft you will probably find yourself wondering, why does the machine I saw on Scicraft not work on my [insert latest version] world? The reason itself is really quite simple, Scicraft is not running [insert latest version>, they run 1.12.2.  
+As well, contrary to popular belief, there are other technical servers, and to top it all off, many of those also run 1.12.x, with some even running more obscure versions including 1.7.2, 1.8.1, 1.13.1, 1.15.2, and more.
 
 ## Mechanics Changes by Version
 ### 1.16
@@ -19,8 +15,10 @@ many of those also run 1.12.x
 - mobs can only go one pack over the mobcap when spawning in a single tick
 - villagers now save their golem spawning cooldown to NBT
 - villagers no longer need to have worked in the past in-game day to spawn golems
+
 ### 1.15
 - mobs despawning now happens the same way in lazy chunks as they do in entity-processing chunks
+
 ### 1.14
 - iron farm/village mechanics drastically changed several times from 1.14-1.14.4, see the iron farming page
 - new chunk loading level (in addition to lazy and entity processing): border, these can only process block events, block updates, and state updates
@@ -28,15 +26,18 @@ many of those also run 1.12.x
 - when an unloaded chunk is accessed, for example by a hopper or a chest, it is loaded as a border chunk for &lt;1gt
 - when an entity goes through a nether portal, a 3x3 of chunks on the destination side is loaded as entity processing for 299gt, which causes the chunks around this 3x3 square and diagonal to the corners to become lazy loaded for that time, and the chunks around that 5x5 square and diagonal to the corners to become border loaded for that time
 - spawning heightmap now checks for all blocks, instead of only light-obstructing blocks.
+
 ### 1.13
 - spawning "heightmap" is per-block instead of per-subchunk
 - mobs no longer spawn outside of the 128m radius sphere centred on the player
 - dragon egg bedrock breaking removed
 - RNG manipulation no longer possible (todo:why)
+
 ### 1.9
 - block 36 now has a hitbox, removing the shifting floor mechanic
 - piston no longer retracts an extended piston when de-powered in the same gametick
 - string no longer breaks when the block below it is retracted
+
 ### 1.8
 - LC value now decreases when skylight-obstructing blocks are removed from upper subchunks
 - light updates no longer affect LC value
@@ -46,11 +47,14 @@ many of those also run 1.12.x
 ### 1.16
 - rails give out significantly less block updates
 - block hitbox shapes are no longer checked individually for a "full top surface," and are instead cached
+
 ### 1.15
 - redstone dust gives out significantly less block updates upon de-powering, as it now de-powers 2 levels at a time instead of 1
 - Portals are now cached via POI which makes going through portals much faster.
+
 ### 1.14
 - Lighting engine was moved to a seperate thread.
+
 ### 1.13
 - "The Flattening" and related changes cause major performance drops across the board in relation to 1.12
 - rails give out significantly more block updates


### PR DESCRIPTION
I've gone through all the pages that exist and have tried to clean up markdown, formatting, indentation/newline issues, comma weirdness, link formatting, etc.

There are still a number of pages that are written quite oddly but rewriting all of those would have taken too long, especially when I don't know all there is about the subjects. This was mostly syntactical and grammar corrections, but I did rewrite some sections of a few pages.

One thing to note: Having non-list-styled text in a list, then nesting into a sub-list and trying to escape out of the nested list makes the github parsing space out all elements in the parent list further for some reason (Happens in the weather section of GameTick, though not a huge issue.) Unsure if that will happen on the actual page though.
Github also formats ordered list within ordered list using roman numerals. Not sure if that's also the case on the page, but in the case of music discs specifically that should then be replaced by a table instead.